### PR TITLE
check_slashing in reinvest

### DIFF
--- a/contracts/airdrops-registry/examples/schema.rs
+++ b/contracts/airdrops-registry/examples/schema.rs
@@ -1,8 +1,10 @@
 use std::env::current_dir;
 use std::fs::create_dir_all;
 
+use airdrops_registry::msg::{
+    ExecuteMsg, GetAirdropContractsResponse, GetConfigResponse, InstantiateMsg, QueryMsg,
+};
 use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
-use airdrops_registry::msg::{GetAirdropContractsResponse, GetConfigResponse, QueryMsg, ExecuteMsg, InstantiateMsg};
 
 use airdrops_registry::state::*;
 
@@ -18,6 +20,4 @@ fn main() {
     export_schema(&schema_for!(Config), &out_dir);
     export_schema(&schema_for!(GetConfigResponse), &out_dir);
     export_schema(&schema_for!(GetAirdropContractsResponse), &out_dir);
-
-
 }

--- a/contracts/airdrops-registry/schema/execute_msg.json
+++ b/contracts/airdrops-registry/schema/execute_msg.json
@@ -11,18 +11,18 @@
         "update_airdrop_registry": {
           "type": "object",
           "required": [
-            "airdrop_contract_str",
-            "airdrop_token_str",
-            "cw20_contract_str"
+            "airdrop_contract",
+            "airdrop_token",
+            "cw20_contract"
           ],
           "properties": {
-            "airdrop_contract_str": {
+            "airdrop_contract": {
               "type": "string"
             },
-            "airdrop_token_str": {
+            "airdrop_token": {
               "type": "string"
             },
-            "cw20_contract_str": {
+            "cw20_contract": {
               "type": "string"
             }
           }

--- a/contracts/airdrops-registry/src/contract.rs
+++ b/contracts/airdrops-registry/src/contract.rs
@@ -43,9 +43,9 @@ pub fn execute(
 ) -> Result<Response, ContractError> {
     match msg {
         ExecuteMsg::UpdateAirdropRegistry {
-            airdrop_token_str,
-            airdrop_contract_str,
-            cw20_contract_str,
+            airdrop_token: airdrop_token_str,
+            airdrop_contract: airdrop_contract_str,
+            cw20_contract: cw20_contract_str,
         } => update_airdrop_registry(
             deps,
             info,

--- a/contracts/airdrops-registry/src/msg.rs
+++ b/contracts/airdrops-registry/src/msg.rs
@@ -12,9 +12,9 @@ pub struct MigrateMsg {}
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
     UpdateAirdropRegistry {
-        airdrop_token_str: String,
-        airdrop_contract_str: String,
-        cw20_contract_str: String,
+        airdrop_token: String,
+        airdrop_contract: String,
+        cw20_contract: String,
     },
 }
 

--- a/contracts/airdrops-registry/src/testing/tests.rs
+++ b/contracts/airdrops-registry/src/testing/tests.rs
@@ -62,9 +62,9 @@ mod tests {
             env.clone(),
             mock_info("not-creator", &[]),
             ExecuteMsg::UpdateAirdropRegistry {
-                airdrop_token_str: "".to_string(),
-                airdrop_contract_str: "".to_string(),
-                cw20_contract_str: "".to_string(),
+                airdrop_token: "".to_string(),
+                airdrop_contract: "".to_string(),
+                cw20_contract: "".to_string(),
             },
         )
         .unwrap_err();
@@ -78,9 +78,9 @@ mod tests {
             env.clone(),
             mock_info("creator", &[]),
             ExecuteMsg::UpdateAirdropRegistry {
-                airdrop_token_str: "".to_string(),
-                airdrop_contract_str: "".to_string(),
-                cw20_contract_str: "".to_string(),
+                airdrop_token: "".to_string(),
+                airdrop_contract: "".to_string(),
+                cw20_contract: "".to_string(),
             },
         )
         .unwrap_err();
@@ -94,9 +94,9 @@ mod tests {
             env.clone(),
             mock_info("creator", &[]),
             ExecuteMsg::UpdateAirdropRegistry {
-                airdrop_token_str: "anc".to_string(),
-                airdrop_contract_str: "anc_airdrop_contract".to_string(),
-                cw20_contract_str: "anc_cw20_contract".to_string(),
+                airdrop_token: "anc".to_string(),
+                airdrop_contract: "anc_airdrop_contract".to_string(),
+                cw20_contract: "anc_cw20_contract".to_string(),
             },
         )
         .unwrap();

--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -537,6 +537,7 @@ pub fn receive_cw20(
             if contract_addr != config.cw20_token_contract {
                 return Err(ContractError::Unauthorized {});
             }
+            // bchain: Note: Undelegating 0 tokens is not possible because the cw20_send call will fail
             Ok(queue_undelegation(
                 deps,
                 env,
@@ -961,7 +962,7 @@ pub fn query_user_undelegation_info(
     batch_id: u64,
 ) -> StdResult<GetFundsClaimRecord> {
     let user_addr = deps.api.addr_validate(user_addr.as_str())?;
-    let funds_record = compute_withdrawable_funds(deps.storage, batch_id, &user_addr).unwrap();
+    let funds_record = compute_withdrawable_funds(deps.storage, batch_id, &user_addr)?;
     Ok(funds_record)
 }
 

--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -849,6 +849,10 @@ pub fn claim_airdrops(
             return Err(ContractError::AirdropNotRegistered(rate.denom));
         };
 
+        if rate.amount.is_zero() {
+            continue;
+        }
+
         let claim_msg = to_binary(&MerkleAirdropMsg::Claim {
             stage: rate.stage,
             amount: rate.amount,

--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -66,6 +66,7 @@ pub fn instantiate(
     CONFIG.save(deps.storage, &config)?;
 
     let initial_er = Decimal::one();
+
     let state = State {
         total_staked: Uint128::zero(),
         exchange_rate: initial_er,
@@ -471,6 +472,8 @@ pub fn reinvest(
     env: Env,
 ) -> Result<Response, ContractError> {
     let config = CONFIG.load(deps.storage)?;
+
+    check_slashing(&mut deps, &env)?;
 
     let mut state = STATE.load(deps.storage)?;
     let balance = deps.querier.query_balance(

--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -431,8 +431,7 @@ pub fn redeem_rewards(
             .is_none()
             || deps
                 .querier
-                .query_delegation(env.contract.address.clone(), val_addr.to_string())
-                .unwrap()
+                .query_delegation(env.contract.address.clone(), val_addr.to_string())?
                 .is_none()
         {
             failed_vals.push(val_addr.to_string());

--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -19,7 +19,7 @@ use airdrops_registry::msg::GetAirdropContractsResponse;
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
     from_binary, to_binary, Addr, BankMsg, Binary, Coin, Decimal, Deps, DepsMut, DistributionMsg,
-    Env, MessageInfo, Order, Response, StakingMsg, StdResult, Storage, Uint128, WasmMsg,
+    Env, MessageInfo, Order, Response, StakingMsg, StdError, StdResult, Storage, Uint128, WasmMsg,
 };
 use cw20::Cw20ReceiveMsg;
 use cw20_base::msg::ExecuteMsg as Cw20ExecuteMsg;
@@ -962,7 +962,8 @@ pub fn query_user_undelegation_info(
     batch_id: u64,
 ) -> StdResult<GetFundsClaimRecord> {
     let user_addr = deps.api.addr_validate(user_addr.as_str())?;
-    let funds_record = compute_withdrawable_funds(deps.storage, batch_id, &user_addr)?;
+    let funds_record = compute_withdrawable_funds(deps.storage, batch_id, &user_addr)
+        .expect("compute_withdrawable_funds failed");
     Ok(funds_record)
 }
 

--- a/contracts/staking/src/error.rs
+++ b/contracts/staking/src/error.rs
@@ -33,8 +33,8 @@ pub enum ContractError {
     #[error("Staking-Contract: No sufficient funds for transfer")]
     InSufficientFunds {},
 
-    #[error("Staking-Contract: Airdrop is not registered")]
-    AirdropNotRegistered {},
+    #[error("Staking-Contract: Airdrop is not registered `{0}`")]
+    AirdropNotRegistered(String),
 
     #[error("Staking-Contract: Amount cannot be zero")]
     ZeroAmount {},

--- a/contracts/staking/src/testing/mock_querier.rs
+++ b/contracts/staking/src/testing/mock_querier.rs
@@ -149,22 +149,27 @@ impl WasmMockQuerier {
                 panic!("WASMQUERY::RAW not implemented!")
             }
             QueryRequest::Wasm(WasmQuery::Smart { contract_addr, msg }) => {
-                if (contract_addr.eq("airdrop_registry_contract")) {
+                if contract_addr.eq("airdrop_registry_contract") {
                     match from_binary(msg).unwrap() {
                         AirdropsQueryMsg::GetAirdropContracts { token } => {
-                            let res = GetAirdropContractsResponse {
-                                contracts: Some(AirdropRegistryInfo {
-                                    token: token.clone(),
-                                    airdrop_contract: Addr::unchecked(format!(
-                                        "{}_airdrop_contract",
-                                        token.clone()
-                                    )),
-                                    cw20_contract: Addr::unchecked(format!(
-                                        "{}_cw20_contract",
-                                        token.clone()
-                                    )),
-                                }),
-                            };
+                            let mut res: GetAirdropContractsResponse;
+                            if token.eq(&String::from("unreg_token")) {
+                                res = GetAirdropContractsResponse { contracts: None };
+                            } else {
+                                res = GetAirdropContractsResponse {
+                                    contracts: Some(AirdropRegistryInfo {
+                                        token: token.clone(),
+                                        airdrop_contract: Addr::unchecked(format!(
+                                            "{}_airdrop_contract",
+                                            token.clone()
+                                        )),
+                                        cw20_contract: Addr::unchecked(format!(
+                                            "{}_cw20_contract",
+                                            token.clone()
+                                        )),
+                                    }),
+                                };
+                            }
                             SystemResult::Ok(ContractResult::from(to_binary(&res)))
                         }
                         _ => {


### PR DESCRIPTION
1. Check for slashing during reinvest
2. Throw an error if airdrop is not registered in the contract.
3. Error out gracefully in get_user_undelegation_info